### PR TITLE
CM3 compability

### DIFF
--- a/usr/local/bin/configure-gadgets
+++ b/usr/local/bin/configure-gadgets
@@ -52,15 +52,3 @@ done
 ls /sys/class/udc > UDC
 
 echo "Mass storage gadget init complete"
-act_led=/sys/class/leds/led0
-echo none > ${act_led}/trigger
-count=0
-while [ $count -lt 3 ]
-do
-   echo 0 > ${act_led}/brightness
-   sleep 0.2
-   echo 255 > ${act_led}/brightness
-   sleep 0.2
-   count=$((count + 1))
-done
-echo "default-on" > ${act_led}/trigger

--- a/usr/local/bin/configure-gadgets
+++ b/usr/local/bin/configure-gadgets
@@ -10,6 +10,12 @@ if [ -d "${CONFIGFS}" ]; then
    teardown || true
 fi
 
+# Disable activity LED, otherwise eMMC will be disabled on CM3
+if [ -e /sys/class/leds/led0 ]; then
+	echo none > /sys/class/leds/led0/trigger
+	echo 0 > /sys/class/leds/led0/brightness
+fi
+
 if lspci | grep -iq "USB Controller"; then
    # For slow to init drives it might be better to use udev events
    # However, that's unecessary complexity for a rare use-case

--- a/usr/local/bin/configure-gadgets
+++ b/usr/local/bin/configure-gadgets
@@ -2,7 +2,6 @@
 
 teardown() {
    umount "${CONFIGFS}" > /dev/null 2>&1
-   rmmod libcomposite > /dev/null 2>&1
    rmdir "${CONFIGFS}"
 }
 
@@ -20,7 +19,6 @@ if lspci | grep -iq "USB Controller"; then
 fi
 
 mkdir -p "${CONFIGFS}"
-modprobe libcomposite
 mount none "${CONFIGFS}" -t configfs
 cd "${CONFIGFS}/usb_gadget"
 mkdir -p rpimsg


### PR DESCRIPTION
With some modification mass storage gadget can also be used on compute module 3. The most important thing is to NOT use the activity led as it conflicts with the EMMC_ENABLE